### PR TITLE
Loosen rules about ++, whitespace and object shorthand

### DIFF
--- a/common.js
+++ b/common.js
@@ -16,6 +16,12 @@ module.exports = {
       "ignoreRegExpLiterals": true,
       "tabWidth": 2,
     }],
+    "no-irregular-whitespace": ["error", {
+      "skipStrings": true,
+      "skipComments": true,
+      "skipRegExps": true,
+      "skipTemplates": true,
+    }],
     "no-plusplus": ["error", {
       "allowForLoopAfterthoughts": true,
     }],

--- a/common.js
+++ b/common.js
@@ -16,6 +16,9 @@ module.exports = {
       "ignoreRegExpLiterals": true,
       "tabWidth": 2,
     }],
+    "no-plusplus": ["error", {
+      "allowForLoopAfterthoughts": true,
+    }],
     "no-prototype-builtins": "off",
     "no-underscore-dangle": "off",
     "quotes": ["error", "double", {

--- a/common.js
+++ b/common.js
@@ -27,6 +27,9 @@ module.exports = {
     }],
     "no-prototype-builtins": "off",
     "no-underscore-dangle": "off",
+    "object-shorthand": ["error", "always", {
+      "avoidQuotes": false,
+    }],
     "quotes": ["error", "double", {
       "avoidEscape": true,
     }],


### PR DESCRIPTION
This PR loosen some rules.

## [no-plusplus](http://eslint.org/docs/rules/no-plusplus)

Unary operators in a `for` loop should be allowed.

```js
for (let i = 0; i < len; i++) {
  // ...
}
```

## [no-irregular-whitespace](http://eslint.org/docs/rules/no-irregular-whitespace)

Sometimes we use full-width spaces in a string, comment, or regexp.
These spaces should be allowed.

## [object-shorthand](http://eslint.org/docs/rules/object-shorthand)

Currently following code is warned.

```js
const obj = {
  "foo-bar"() {},
}
```

But I think using function declaration is a bit verbose
(anonymous function is prohibited by the `func-names` rule).

```js
const obj = {
  "foo-bar": function fooBar() {},
}
```

Though we can use arrow function in most cases, there is a case that we need to access `this` inside the function.

```js
const obj = {
  "foo-bar": () => { /* Code without `this` works fine */ },
}
```

We can configure ESLint to allow the first pattern by disabling `avoidQuotes` option.
