### PR TITLE
refactor: remove duplicated `parserOptions`

### DIFF
--- a/common.js
+++ b/common.js
@@ -1,12 +1,4 @@
 module.exports = {
-  "parserOptions": {
-    "ecmaVersion": 6,
-    "sourceType": "module",
-    "ecmaFeatures": {
-      "experimentalObjectRestSpread": true,
-    },
-  },
-
   "plugins": [
     "eslint-comments",
   ],


### PR DESCRIPTION
The `parserOptions` entry is already defined in `eslint-config-airbnb-base`.
See https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/index.js#L11

The difference is only below:

```
- "ecmaVersion": 6,
+ "ecmaVersion": 2017,
```

The below command is utility in order to show entire ESLint configuration:

```
./node_modules/.bin/eslint --print-config common.js
```