### PR TITLE
Update Slack token for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ script:
   - yarn test
 notifications:
   email: false
-  slack: interfirm:L2WhP1umnVtkeYcz6Uedkocs#developer
+  slack: interfirm:nQ2iFItAwPADePQlPgmcVE2D#developer
 deploy:
   provider: npm
   email: register@interfirm.co.jp


### PR DESCRIPTION
connect to interfirm/etc#157

SlackのIntegration設定を`interfirm`アカウントで作り直したので、Tokenが変わりました。
(No reviews needed)