### PR TITLE
ESLint の recommended rules を有効にする

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,6 @@
 module.exports = {
+  env: {
+    node: true,
+  },
   extends: ["./react.js", "prettier"],
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -4,4 +4,3 @@
   "singleQuote": false,
   "trailingComma": "es5"
 }
-

--- a/base.js
+++ b/base.js
@@ -1,6 +1,8 @@
 module.exports = {
   plugins: ["import", "eslint-comments"],
 
+  extends: ["eslint:recommended"],
+
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: "module",
@@ -33,8 +35,6 @@ module.exports = {
         allowForLoopAfterthoughts: true,
       },
     ],
-    "no-prototype-builtins": "off",
-    "no-underscore-dangle": "off",
     "object-shorthand": [
       "error",
       "always",
@@ -59,6 +59,5 @@ module.exports = {
     "eslint-comments/no-unlimited-disable": "error",
     "eslint-comments/no-unused-disable": "error",
     "eslint-comments/no-unused-enable": "error",
-    "eslint-comments/no-use": "off",
   },
 }


### PR DESCRIPTION
#100 で`eslint-config-airbnb`を消した時、`no-unused-vars`などの必須ルールも無効になってしまってた事を見落としていた。 https://eslint.org/docs/rules/ を見ると recommended ルールはどれも良さそうなので、`eslint:recommended`を使うようにする。